### PR TITLE
Refine ExplainEnv to accept external datasets

### DIFF
--- a/src/agents/agent_langchain.py
+++ b/src/agents/agent_langchain.py
@@ -1,21 +1,361 @@
 from __future__ import annotations
-from typing import Callable, Dict, Any
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, TYPE_CHECKING
+
 import numpy as np
 
-# This stub imitates a tool-using policy. Replace with LangChain or your LLM of choice.
-class ToolUsingPolicy:
-    def __init__(self, tools: Dict[str, Callable], seed: int = 0):
-        self.tools = tools
-        self.rng = np.random.default_rng(seed)
+if TYPE_CHECKING:  # pragma: no cover - import hints for type checking only
+    from langchain_core.language_models import BaseLanguageModel
+    from langchain_core.messages import AIMessage, HumanMessage
 
-    def generate_explanation(self, x: np.ndarray, p: Any) -> str:
-        # Heuristic: call feature importance, then craft a sentence.
-        feats = self.tools["get_feature_importance"](x)
-        parts = []
-        for idx, val in feats:
-            direction = "increases" if val > 0 else "decreases"
-            parts.append(f"feature[{idx}] {direction} the odds of class 1 by ~{abs(val):.2f}")
-        template = (
-            "Based on local attributions, {details}. Overall, the model probability for class 1 is {p1:.2f}."
+
+try:  # pragma: no cover - exercised via dedicated test
+    from langchain_core.language_models import BaseLanguageModel as _BaseLanguageModel
+    from langchain_core.messages import AIMessage as _AIMessage
+    from langchain_core.messages import HumanMessage as _HumanMessage
+except ImportError as exc:  # pragma: no cover - behaviour validated in tests
+    _BaseLanguageModel = None  # type: ignore[assignment]
+    _AIMessage = None  # type: ignore[assignment]
+    _HumanMessage = None  # type: ignore[assignment]
+    _LANGCHAIN_IMPORT_ERROR = exc
+else:
+    _LANGCHAIN_IMPORT_ERROR = None
+
+
+@dataclass
+class _AgentState:
+    """Holds intermediate results collected by the agent."""
+
+    feature_importance: Optional[List[Tuple[int, float]]] = None
+    local_explanation: Any = None
+    partial_dependence: Any = None
+    top_feature_index: Optional[int] = None
+
+
+class ToolUsingPolicy:
+    """LangChain-powered policy that orchestrates explanation tools via ReAct."""
+
+    REQUIRED_TOOLS: Tuple[str, str, str] = (
+        "get_feature_importance",
+        "get_local_explanation",
+        "get_partial_dependence",
+    )
+
+    def __init__(
+        self,
+        tools: Dict[str, Callable[..., Any]],
+        llm: "BaseLanguageModel",
+        *,
+        max_tool_calls: int = 3,
+    ) -> None:
+        if _LANGCHAIN_IMPORT_ERROR is not None:
+            raise ImportError(
+                "LangChain is required for ToolUsingPolicy. Install `langchain` to enable this agent."
+            ) from _LANGCHAIN_IMPORT_ERROR
+
+        if _BaseLanguageModel is not None and not isinstance(llm, _BaseLanguageModel):
+            raise TypeError("llm must inherit from langchain_core.language_models.BaseLanguageModel")
+
+        if max_tool_calls < 1:
+            raise ValueError("max_tool_calls must be at least 1")
+
+        missing = [name for name in self.REQUIRED_TOOLS if name not in tools]
+        if missing:
+            raise KeyError(f"Missing required tools: {', '.join(missing)}")
+
+        self._tools = tools
+        self._llm = llm
+        self._max_tool_calls = max_tool_calls
+
+    def generate_explanation(self, x: np.ndarray, p: np.ndarray) -> str:
+        """Run a ReAct-style loop to obtain a cited explanation for ``x``."""
+
+        state = _AgentState()
+        scratchpad: List[str] = []
+        calls_used = 0
+        x_list = _ensure_list(x)
+        p_list = _ensure_list(p)
+
+        # Allow an extra iteration for the final response.
+        for iteration in range(self._max_tool_calls + 1):
+            prompt = self._render_prompt(x_list, p_list, scratchpad, calls_used, iteration)
+            messages = [_HumanMessage(content=prompt)] if _HumanMessage else [prompt]  # type: ignore[list-item]
+            response = self._llm.invoke(messages)
+            content = getattr(response, "content", response)
+            step = self._parse_step(content)
+
+            thought = step.get("thought", "")
+            if thought:
+                scratchpad.append(f"Thought {iteration + 1}: {thought}")
+
+            if "action" in step and calls_used < self._max_tool_calls:
+                action = step["action"]
+                observation = self._execute_action(action, x_list, state)
+                scratchpad.append(f"Action {calls_used + 1}: {self._format_action(action)}")
+                scratchpad.append(f"Observation {calls_used + 1}: {observation}")
+                calls_used += 1
+                # Continue loop to obtain next instruction or final response.
+
+            if "final" in step:
+                break
+
+            if calls_used >= self._max_tool_calls and "action" not in step:
+                # Agent hit the tool budget without a final response; exit loop.
+                break
+
+        if state.feature_importance is None:
+            raise RuntimeError("Agent did not gather feature importance before finishing.")
+
+        if state.partial_dependence is None and state.top_feature_index is not None:
+            # Ensure partial dependence is available as required.
+            pd_result = self._tools["get_partial_dependence"](
+                x=x_list,
+                feature_i=int(state.top_feature_index),
+            )
+            state.partial_dependence = pd_result
+
+        return self._build_summary(p_list, state)
+
+    def _render_prompt(
+        self,
+        x_list: List[Any],
+        p_list: List[Any],
+        scratchpad: Sequence[str],
+        calls_used: int,
+        iteration: int,
+    ) -> str:
+        scratchpad_text = "\n".join(scratchpad) if scratchpad else "(no tool calls yet)"
+        remaining = self._max_tool_calls - calls_used
+        return (
+            "You are a LangChain ReAct agent that explains model predictions using tools.\n"
+            "Available tools: get_feature_importance(x), get_local_explanation(x), get_partial_dependence(x, feature_i).\n"
+            "Always reply with valid JSON containing a 'thought' key and either an 'action' object or a 'final' key.\n"
+            "Actions must be JSON objects like {'tool': 'tool_name', 'args': {...}} using only JSON-compatible values.\n"
+            "Call get_partial_dependence on the feature index with the largest absolute SHAP score.\n"
+            f"Remaining tool calls: {remaining}.\n"
+            f"Iteration: {iteration + 1}.\n"
+            f"Feature vector x: {x_list}.\n"
+            f"Prediction p: {p_list}.\n"
+            "Scratchpad so far:\n"
+            f"{scratchpad_text}\n"
+            "Reply with JSON only."
         )
-        return template.format(details="; ".join(parts), p1=float(p[1]) if hasattr(p, '__getitem__') else float(p))
+
+    def _parse_step(self, content: Any) -> Dict[str, Any]:
+        if _AIMessage is not None and isinstance(content, _AIMessage):
+            content = content.content
+        elif _HumanMessage is not None and isinstance(content, _HumanMessage):
+            content = content.content
+
+        if not isinstance(content, str):
+            raise ValueError(f"LLM response must be a JSON string, received {type(content)!r}")
+
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as exc:  # pragma: no cover - error surface guarded in tests
+            raise ValueError("LLM response was not valid JSON") from exc
+        if not isinstance(data, dict):
+            raise ValueError("LLM response must decode to a JSON object")
+        if "thought" not in data:
+            raise ValueError("LLM response is missing the required 'thought' field")
+        return data
+
+    def _execute_action(self, action: Dict[str, Any], x_list: List[Any], state: _AgentState) -> str:
+        tool_name = action.get("tool")
+        if not isinstance(tool_name, str):
+            raise ValueError("Action must specify a tool name")
+
+        if tool_name not in self._tools:
+            raise KeyError(f"Unknown tool requested: {tool_name}")
+
+        raw_args = action.get("args", {})
+        if raw_args is None:
+            raw_args = {}
+        if not isinstance(raw_args, dict):
+            raise ValueError("Action 'args' must be a JSON object")
+
+        prepared_args = self._prepare_tool_args(tool_name, raw_args, x_list, state)
+        result = self._tools[tool_name](**prepared_args)
+
+        if tool_name == "get_feature_importance":
+            state.feature_importance = self._normalize_feature_importance(result)
+            if not state.feature_importance:
+                raise ValueError("Feature importance tool returned no attributions")
+            state.top_feature_index = int(state.feature_importance[0][0])
+            return self._summarize_feature_importance(state.feature_importance)
+
+        if tool_name == "get_local_explanation":
+            state.local_explanation = result
+            return self._summarize_local_explanation(result)
+
+        # Partial dependence must use the top feature index when available.
+        if state.top_feature_index is None:
+            raise RuntimeError("Partial dependence requested before feature importance was available")
+
+        state.partial_dependence = result
+        return self._summarize_partial_dependence(result, state.top_feature_index)
+
+    def _prepare_tool_args(
+        self,
+        tool_name: str,
+        raw_args: Dict[str, Any],
+        x_list: List[Any],
+        state: _AgentState,
+    ) -> Dict[str, Any]:
+        args: Dict[str, Any] = {}
+        for key, value in raw_args.items():
+            if isinstance(value, np.ndarray):
+                args[key] = value.tolist()
+            else:
+                args[key] = value
+
+        args.setdefault("x", list(x_list))
+
+        if tool_name == "get_partial_dependence":
+            feature_idx: Optional[int]
+            if state.top_feature_index is not None:
+                feature_idx = int(state.top_feature_index)
+            else:
+                raw_idx = args.get("feature_i")
+                feature_idx = None if raw_idx is None else int(raw_idx)
+
+            if feature_idx is None:
+                raise RuntimeError("Cannot compute partial dependence without a feature index")
+
+            args["feature_i"] = feature_idx
+
+        return args
+
+    def _build_summary(self, p_list: List[Any], state: _AgentState) -> str:
+        shap_values = state.feature_importance or []
+        if not shap_values:
+            raise RuntimeError("Missing feature importance values for summary")
+
+        top_idx, top_value = shap_values[0]
+        shap_text = f"SHAP: f[{int(top_idx)}]={float(top_value):+0.2f}"
+
+        local_text = self._format_local_explanation(state.local_explanation)
+        pdp_text = self._format_partial_dependence(state.partial_dependence, int(top_idx))
+
+        citations = [shap_text]
+        if local_text:
+            citations.append(local_text)
+        if pdp_text:
+            citations.append(pdp_text)
+
+        prob_text = ", ".join(f"{float(prob):0.2f}" for prob in _flatten_probs(p_list))
+        explanation = f"{' ; '.join(citations)}. Predicted probs=[{prob_text}]."
+
+        if len(explanation.split()) > 150:
+            explanation = f"{' ; '.join(citations[:3])}."
+
+        return explanation
+
+    def _summarize_feature_importance(self, values: List[Tuple[int, float]]) -> str:
+        highlights = ", ".join(
+            f"f{int(idx)}:{float(val):+0.2f}" for idx, val in values[:3]
+        )
+        return f"Top SHAP attributions -> {highlights}"
+
+    def _summarize_local_explanation(self, result: Any) -> str:
+        return f"Local explanation: {self._format_local_explanation(result)}"
+
+    def _summarize_partial_dependence(self, result: Any, feature_idx: int) -> str:
+        detail = self._format_partial_dependence(result, feature_idx)
+        return f"Partial dependence insight: {detail}" if detail else "Partial dependence insight: (none)"
+
+    def _normalize_feature_importance(
+        self, raw: Any
+    ) -> List[Tuple[int, float]]:
+        if isinstance(raw, dict):
+            items = list(raw.items())
+        else:
+            items = list(raw)
+
+        normalized: List[Tuple[int, float]] = []
+        for entry in items:
+            if isinstance(entry, Iterable) and not isinstance(entry, (str, bytes)):
+                entry_list = list(entry)
+                if len(entry_list) < 2:
+                    continue
+                idx, value = entry_list[0], entry_list[1]
+            else:
+                raise ValueError("Feature importance entries must be iterable pairs")
+
+            normalized.append((int(idx), float(value)))
+
+        normalized.sort(key=lambda item: abs(item[1]), reverse=True)
+        return normalized
+
+    def _format_action(self, action: Dict[str, Any]) -> str:
+        tool = action.get("tool", "?")
+        args = action.get("args", {})
+        return f"{tool}({args})"
+
+    def _format_local_explanation(self, result: Any) -> str:
+        if result is None:
+            return ""
+        if isinstance(result, dict):
+            method = str(result.get("method") or result.get("name") or "local")
+            metric_name, metric_value = self._pick_metric(result)
+            if metric_name:
+                return f"{method} {metric_name}={metric_value}"
+            return f"{method} details={self._shorten(str(result))}"
+        if isinstance(result, (list, tuple)):
+            return self._shorten(", ".join(map(str, result)))
+        return self._shorten(str(result))
+
+    def _format_partial_dependence(self, result: Any, feature_idx: int) -> str:
+        if result is None:
+            return ""
+        detail: str
+        if isinstance(result, dict):
+            for key in ("trend", "summary", "shape", "direction"):
+                if key in result:
+                    detail = str(result[key])
+                    break
+            else:
+                if "slope" in result:
+                    value = result["slope"]
+                    detail = f"slope={value:0.2f}" if isinstance(value, (int, float)) else str(value)
+                else:
+                    detail = self._shorten(str(result))
+        elif isinstance(result, (list, tuple)):
+            detail = self._shorten(", ".join(map(str, result[:5])))
+        else:
+            detail = self._shorten(str(result))
+
+        return f"PDP@f{int(feature_idx)} {detail}"
+
+    def _pick_metric(self, data: Dict[str, Any]) -> Tuple[Optional[str], Optional[str]]:
+        for key in ("score", "r2", "r_squared", "fidelity", "accuracy"):
+            if key in data:
+                value = data[key]
+                if isinstance(value, (int, float)):
+                    return key, f"{value:0.2f}"
+                return key, self._shorten(str(value))
+        return None, None
+
+    def _shorten(self, text: str, max_len: int = 60) -> str:
+        return text if len(text) <= max_len else text[: max_len - 3] + "..."
+
+
+def _ensure_list(value: Any) -> List[Any]:
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
+def _flatten_probs(values: Sequence[Any]) -> List[float]:
+    flat: List[float] = []
+    for value in values:
+        if isinstance(value, (list, tuple)):
+            flat.extend(float(v) for v in value)
+        else:
+            flat.append(float(value))
+    return flat
+

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,5 @@
+"""Data utilities for tabular experiments."""
+
+from .datasets import TabularDataset
+
+__all__ = ["TabularDataset"]

--- a/src/data/datasets.py
+++ b/src/data/datasets.py
@@ -1,0 +1,189 @@
+"""Minimal tabular dataset abstractions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class TabularDataset:
+    """A simple wrapper around tabular features and labels.
+
+    The dataset stores feature matrices ``X`` and corresponding labels ``y``
+    while offering helpers to build from NumPy arrays or pandas ``DataFrame``
+    objects.  It also exposes basic sampling and splitting utilities that are
+    convenient for quick experiments and tests.
+    """
+
+    _X: np.ndarray
+    _y: np.ndarray
+    _feature_names: Optional[List[str]] = None
+
+    def __post_init__(self) -> None:
+        """Validate invariants after initialization."""
+        if self._X.ndim != 2:
+            raise ValueError("X must be a 2D array")
+        if self._y.ndim != 1:
+            raise ValueError("y must be a 1D array")
+        if self._X.shape[0] != self._y.shape[0]:
+            raise ValueError("X and y must contain the same number of rows")
+        if self._feature_names is not None and len(self._feature_names) != self._X.shape[1]:
+            raise ValueError("feature_names must match the number of columns in X")
+
+    @classmethod
+    def from_arrays(
+        cls,
+        X: np.ndarray,
+        y: np.ndarray,
+        feature_names: Optional[Sequence[str]] = None,
+    ) -> "TabularDataset":
+        """Construct a dataset from raw NumPy arrays.
+
+        Args:
+            X: Feature matrix with shape ``(n_samples, n_features)``.
+            y: Label vector with shape ``(n_samples,)``.
+            feature_names: Optional iterable of feature names.
+
+        Returns:
+            A :class:`TabularDataset` instance.
+        """
+
+        X_arr = np.asarray(X)
+        y_arr = np.asarray(y)
+        names = list(feature_names) if feature_names is not None else None
+        return cls(X_arr, y_arr, names)
+
+    @classmethod
+    def from_dataframe(
+        cls,
+        df: pd.DataFrame,
+        label_col: str,
+        feature_cols: Optional[Sequence[str]] = None,
+    ) -> "TabularDataset":
+        """Construct a dataset from a pandas ``DataFrame``.
+
+        Args:
+            df: Input dataframe containing features and labels.
+            label_col: Name of the column containing labels.
+            feature_cols: Optional sequence specifying which columns to use as
+                features.  When ``None`` all columns except ``label_col`` are
+                treated as features.
+
+        Returns:
+            A :class:`TabularDataset` with data extracted from ``df``.
+        """
+
+        if label_col not in df.columns:
+            raise KeyError(f"Label column '{label_col}' not found in dataframe")
+
+        if feature_cols is None:
+            feature_cols = [col for col in df.columns if col != label_col]
+        else:
+            missing = [col for col in feature_cols if col not in df.columns]
+            if missing:
+                raise KeyError(f"Feature columns not found in dataframe: {missing}")
+
+        X = df.loc[:, feature_cols].to_numpy()
+        y = df[label_col].to_numpy()
+        return cls(X, y, list(feature_cols))
+
+    def split(
+        self,
+        train: float = 0.7,
+        val: float = 0.15,
+        test: float = 0.15,
+        seed: int = 0,
+    ) -> Tuple["TabularDataset", "TabularDataset", "TabularDataset"]:
+        """Split the dataset into train/validation/test subsets.
+
+        Fractions default to ``0.7/0.15/0.15`` and must sum to one (within a
+        small tolerance).  Splits are created by shuffling indices with the
+        provided ``seed``.
+        """
+
+        total = train + val + test
+        if not np.isclose(total, 1.0, atol=1e-6):
+            raise ValueError("Split fractions must sum to 1.0")
+
+        n_samples = len(self)
+        indices = np.arange(n_samples)
+        rng = np.random.default_rng(seed)
+        rng.shuffle(indices)
+
+        train_end = int(round(train * n_samples))
+        val_end = train_end + int(round(val * n_samples))
+        val_end = min(val_end, n_samples)
+
+        train_idx = indices[:train_end]
+        val_idx = indices[train_end:val_end]
+        test_idx = indices[val_end:]
+
+        return (
+            self._subset(train_idx),
+            self._subset(val_idx),
+            self._subset(test_idx),
+        )
+
+    def sample(self, n: int = 1, seed: Optional[int] = None) -> np.ndarray:
+        """Sample ``n`` feature rows without replacement."""
+
+        if n < 0:
+            raise ValueError("n must be non-negative")
+        if n > len(self):
+            raise ValueError("Cannot sample more rows than available")
+
+        rng = np.random.default_rng(seed)
+        indices = rng.choice(len(self), size=n, replace=False) if n else np.array([], dtype=int)
+        return self._X[indices]
+
+    def get_row(self, i: int) -> Tuple[np.ndarray, int]:
+        """Return the ``i``-th feature row and label."""
+
+        if i < 0 or i >= len(self):
+            raise IndexError("Row index out of range")
+        x = self._X[i]
+        y = int(self._y[i])
+        return x, y
+
+    @property
+    def X(self) -> np.ndarray:
+        """Underlying feature matrix."""
+
+        return self._X
+
+    @property
+    def y(self) -> np.ndarray:
+        """Underlying label vector."""
+
+        return self._y
+
+    @property
+    def n_features(self) -> int:
+        """Number of feature columns."""
+
+        return self._X.shape[1]
+
+    @property
+    def feature_names(self) -> Optional[List[str]]:
+        """Optional feature names associated with columns of ``X``."""
+
+        return self._feature_names
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return self._X.shape[0]
+
+    def _subset(self, indices: np.ndarray) -> "TabularDataset":
+        """Create a dataset from a subset of indices."""
+
+        if indices.size == 0:
+            X = self._X[:0].copy()
+            y = self._y[:0].copy()
+        else:
+            X = self._X[indices].copy()
+            y = self._y[indices].copy()
+        names = list(self._feature_names) if self._feature_names is not None else None
+        return TabularDataset(X, y, names)

--- a/src/envs/explain_env.py
+++ b/src/envs/explain_env.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 from dataclasses import dataclass
-import numpy as np
-from typing import Dict, Any
+from typing import Any, Dict
 
+import numpy as np
+
+from src.data.datasets import TabularDataset
 from src.models.blackbox import BlackBoxModel
 from src.models.g_explainer import ExplanationInducedModel
 from src.utils.reward import neg_kl_reward
@@ -16,29 +18,72 @@ class StepOutput:
 
 class ExplainEnv:
     """A minimal environment:
-    - reset() returns an x and f(x)
-    - step(explanation) computes g(E) and returns reward = -KL(f(x)||g(E)).
+    - reset() returns an x and either f(x) or its label depending on the reveal mode
+    - step(explanation, tool_call_count) computes g(E) and returns reward = -KL(f(x)||g(E))
+      minus a penalty for tool usage.
     """
-    def __init__(self, n_features: int = 10, seed: int = 0):
-        self.rng = np.random.default_rng(seed)
-        self.f = BlackBoxModel(n_features=n_features, random_state=seed)
+
+    def __init__(
+        self,
+        *,
+        dataset: TabularDataset,
+        blackbox: BlackBoxModel,
+        reveal: str = "probs",
+        tool_penalty: float = 0.0,
+        seed: int = 0,
+    ):
+        if reveal not in {"probs", "label"}:
+            raise ValueError(f"Unsupported reveal mode: {reveal}")
+
+        self.dataset = dataset
+        self.blackbox = blackbox
         self.g = ExplanationInducedModel()
         self.g.fit_dummy()
+
+        self.reveal = reveal
+        self.tool_penalty = float(tool_penalty)
+        self._next_seed = int(seed)
+
         self.current_x = None
         self.current_p = None
         self.t = 0
 
+    def _sample_from_dataset(self) -> np.ndarray:
+        sample_seed = self._next_seed
+        self._next_seed += 1
+        batch = self.dataset.sample(n=1, seed=sample_seed)
+        if batch.shape[0] != 1:
+            raise ValueError("Dataset sampling must return a single row for n=1")
+        return np.array(batch[0], copy=True)
+
+    def _current_observation(self) -> Dict[str, Any]:
+        obs: Dict[str, Any] = {"x": self.current_x}
+        if self.reveal == "probs":
+            obs["p"] = self.current_p
+        else:
+            obs["y"] = int(self.current_p[1] > 0.5)
+        return obs
+
     def reset(self) -> Dict[str, Any]:
         self.t = 0
-        self.current_x = self.rng.normal(0, 1, size=self.f.n_features)
-        self.current_p = self.f.predict_proba(self.current_x)
-        return {"x": self.current_x, "p": self.current_p}
+        self.current_x = self._sample_from_dataset()
+        self.current_p = self.blackbox.predict_proba(self.current_x)
+        return self._current_observation()
 
-    def step(self, explanation: str) -> StepOutput:
+    def step(self, explanation: str, tool_call_count: int = 0) -> StepOutput:
         q = self.g.predict_proba([explanation])[0]  # [p0, p1]
-        reward = neg_kl_reward(self.current_p, q)
+        base_reward = neg_kl_reward(self.current_p, q)
+        reward = base_reward - self.tool_penalty * tool_call_count
         self.t += 1
         done = True  # single-step episodes (x -> E)
-        obs = {"x": self.current_x, "p": self.current_p, "explanation": explanation, "q": q}
-        info = {}
+        obs = self._current_observation()
+        obs.update({"explanation": explanation, "q": q})
+        info: Dict[str, Any] = {
+            "tool_call_count": tool_call_count,
+            "base_reward": base_reward,
+        }
         return StepOutput(observation=obs, reward=reward, done=done, info=info)
+
+    @property
+    def feature_names(self) -> list[str] | None:
+        return self.dataset.feature_names

--- a/src/models/blackbox.py
+++ b/src/models/blackbox.py
@@ -1,20 +1,100 @@
 from __future__ import annotations
+
+from typing import Any, Callable, Mapping, Sequence
+
 import numpy as np
-from sklearn.datasets import make_classification
-from sklearn.linear_model import LogisticRegression
+
+from src.data.datasets import TabularDataset
+
 
 class BlackBoxModel:
-    """Opaque binary classifier f: X -> [0,1]^2 with predict_proba."""
-    def __init__(self, n_features: int = 10, random_state: int = 0):
-        X, y = make_classification(n_samples=500, n_features=n_features, n_informative=6,
-                                   n_redundant=2, n_classes=2, random_state=random_state)
-        self.model = LogisticRegression(max_iter=1000).fit(X, y)
-        self.n_features = n_features
+    """Opaque binary classifier f: X -> [0, 1]^2 with ``predict_proba`` only."""
+
+    def __init__(
+        self,
+        estimator: Any,
+        n_features: int,
+        class_order: Sequence[int] | None = None,
+    ) -> None:
+        if not hasattr(estimator, "predict_proba"):
+            raise ValueError(
+                "Estimator must expose predict_proba; calibrate or wrap the model first."
+            )
+
+        self._estimator = estimator
+        self.n_features = int(n_features)
+        self._class_order = list(class_order) if class_order is not None else [0, 1]
+        self._class_indices = self._resolve_class_indices()
+
+    @classmethod
+    def from_sklearn(
+        cls,
+        estimator: Any,
+        n_features: int,
+        class_order: Sequence[int] | None = None,
+    ) -> "BlackBoxModel":
+        """Wrap a pre-trained sklearn-style estimator."""
+
+        return cls(estimator=estimator, n_features=n_features, class_order=class_order)
+
+    @classmethod
+    def from_training(
+        cls,
+        dataset: TabularDataset,
+        estimator_factory: Callable[[], Any],
+        fit_kwargs: Mapping[str, Any] | None = None,
+        class_order: Sequence[int] | None = None,
+    ) -> "BlackBoxModel":
+        """Train a new estimator on the provided ``TabularDataset`` and wrap it."""
+
+        estimator = estimator_factory()
+        if not hasattr(estimator, "fit"):
+            raise ValueError("estimator_factory must create an object with a fit method")
+
+        kwargs = dict(fit_kwargs or {})
+        estimator.fit(dataset.X, dataset.y, **kwargs)
+        return cls(
+            estimator=estimator,
+            n_features=dataset.n_features,
+            class_order=class_order,
+        )
 
     def predict_proba(self, x: np.ndarray) -> np.ndarray:
-        """Return P(y|x) as [p0, p1]. Accepts shape (n_features,) or (batch, n_features)."""
-        x = np.atleast_2d(x)
-        prob = self.model.predict_proba(x)
-        return prob.squeeze()
+        """Return ``P(y|x)`` as ``[p0, p1]`` while accepting 1-D or batched input."""
 
-    # The 'opaque' interface: no attributes of the model are exposed to the policy.
+        array = np.asarray(x)
+        was_1d = array.ndim == 1
+        batch = np.atleast_2d(array)
+        if batch.shape[1] != self.n_features:
+            raise ValueError(
+                f"Expected input with {self.n_features} features, received {batch.shape[1]}"
+            )
+
+        probs = np.asarray(self._estimator.predict_proba(batch))
+        if probs.ndim != 2:
+            raise ValueError("predict_proba must return a 2D array")
+
+        if probs.shape[1] < len(self._class_order):
+            raise ValueError("predict_proba returned fewer classes than expected")
+
+        if self._class_indices is not None:
+            probs = probs[:, self._class_indices]
+
+        return probs[0] if was_1d else probs
+
+    def _resolve_class_indices(self) -> np.ndarray | None:
+        classes = getattr(self._estimator, "classes_", None)
+        if classes is None:
+            return None
+
+        class_list = list(classes)
+        indices: list[int] = []
+        for cls in self._class_order:
+            if cls not in class_list:
+                raise ValueError(
+                    f"Estimator is missing class {cls}; available classes: {class_list}"
+                )
+            indices.append(class_list.index(cls))
+        return np.asarray(indices, dtype=int)
+
+    # The 'opaque' interface: no attributes of the estimator are exposed to the policy.

--- a/src/models/g_explainer.py
+++ b/src/models/g_explainer.py
@@ -1,28 +1,181 @@
 from __future__ import annotations
+
+import hashlib
+import warnings
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import joblib
 import numpy as np
-from sklearn.feature_extraction.text import CountVectorizer
 from sklearn.linear_model import LogisticRegression
 
+try:  # pragma: no cover - optional dependency
+    from sentence_transformers import SentenceTransformer
+except ImportError:  # pragma: no cover - handled via fallback encoder
+    SentenceTransformer = None
+
+
+class _HashingSentenceEncoder:
+    """Deterministic fallback encoder when sentence-transformers is unavailable."""
+
+    def __init__(self, dim: int = 384):
+        self.dim = dim
+
+    def encode(self, sentences: Iterable[str]) -> np.ndarray:
+        sentences = list(sentences)
+        vectors = np.zeros((len(sentences), self.dim), dtype=np.float32)
+        for row, sentence in enumerate(sentences):
+            tokens = sentence.lower().split()
+            if not tokens:
+                continue
+            for token in tokens:
+                digest = hashlib.sha256(token.encode("utf-8")).digest()
+                index = int.from_bytes(digest[:4], "little") % self.dim
+                sign = 1.0 if digest[4] % 2 == 0 else -1.0
+                vectors[row, index] += sign
+            vectors[row] /= max(1, len(tokens))
+        return vectors
+
+
 class ExplanationInducedModel:
-    """g(E): simple bag-of-words -> logistic over classes {0,1}."""
-    def __init__(self):
-        self.vectorizer = CountVectorizer(ngram_range=(1,2), min_df=1)
+    """g(E): sentence embedding + logistic model over {0, 1}."""
+
+    def __init__(
+        self,
+        model_name: str = "sentence-transformers/all-MiniLM-L6-v2",
+        embedding_dim: int = 384,
+        device: str | None = None,
+    ) -> None:
+        self.model_name = model_name
+        self.embedding_dim = embedding_dim
+        self.device = device
+
+        self._encoder = self._load_encoder()
         self.clf = LogisticRegression(max_iter=1000)
+        self.is_fitted = False
 
-    def fit_dummy(self):
-        """Train a tiny prior so g is well-posed before RL.
-        We fit on templated data linking words to class hints."""
+    # ------------------------------------------------------------------
+    # Encoder utilities
+    # ------------------------------------------------------------------
+    def _load_encoder(self):
+        if SentenceTransformer is None:
+            warnings.warn(
+                "sentence-transformers is not installed; falling back to hashing encoder.",
+                RuntimeWarning,
+            )
+            self._using_sentence_transformer = False
+            return _HashingSentenceEncoder(self.embedding_dim)
+
+        try:
+            encoder = SentenceTransformer(self.model_name, device=self.device)
+            self._using_sentence_transformer = True
+            return encoder
+        except Exception as exc:  # pragma: no cover - exercised when download fails
+            warnings.warn(
+                f"Failed to load SentenceTransformer '{self.model_name}': {exc}. "
+                "Falling back to hashing encoder.",
+                RuntimeWarning,
+            )
+            self._using_sentence_transformer = False
+            return _HashingSentenceEncoder(self.embedding_dim)
+
+    def _encode(self, explanations: Sequence[str]) -> np.ndarray:
+        if self._using_sentence_transformer:
+            vectors = self._encoder.encode(
+                list(explanations), show_progress_bar=False
+            )
+        else:
+            vectors = self._encoder.encode(list(explanations))
+        vectors = np.asarray(vectors, dtype=np.float32)
+        if vectors.ndim == 1:
+            vectors = vectors.reshape(1, -1)
+        return vectors
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def fit_dummy(self) -> None:
+        """Train a tiny prior so g is well-posed before RL."""
         texts = [
-            "evidence indicates class 0 due to low risk",
-            "features suggest class 1 with strong signal",
-            "likely class 0 because negative contribution",
-            "likely class 1 because positive contribution"
+            "evidence indicates outcome 0 due to low risk factors",
+            "strong contributing features suggest outcome 1",
+            "negative contribution explains prediction 0",
+            "positive contribution explains prediction 1",
+            "lack of activating signals keeps class near 0",
+            "supporting evidence pushes confidence toward class 1",
+            "risk mitigation justifies probability of class 0",
+            "dominant signal increases likelihood of class 1",
         ]
-        y = np.array([0,1,0,1])
-        X = self.vectorizer.fit_transform(texts)
-        self.clf.fit(X, y)
+        y = [0, 1, 0, 1, 0, 1, 0, 1]
+        self.fit(texts, y)
 
-    def predict_proba(self, explanations: list[str]) -> np.ndarray:
-        X = self.vectorizer.transform(explanations)
-        proba1 = self.clf.predict_proba(X)  # [:, 1]
-        return proba1  # shape (n, 2)
+    def fit(self, explanations: Sequence[str], y: Sequence[int]) -> None:
+        if len(explanations) == 0:
+            raise ValueError("explanations must be a non-empty sequence")
+        if len(explanations) != len(y):
+            raise ValueError("explanations and y must have the same length")
+
+        embeddings = self._encode(explanations)
+        targets = np.asarray(y)
+        self.clf.fit(embeddings, targets)
+        self.is_fitted = True
+
+    def predict_proba(self, explanations: Sequence[str]) -> np.ndarray:
+        if not self.is_fitted:
+            raise RuntimeError("ExplanationInducedModel must be fitted before prediction")
+        embeddings = self._encode(explanations)
+        return self.clf.predict_proba(embeddings)
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+    def save(self, path: str | Path) -> None:
+        path = Path(path)
+        path.mkdir(parents=True, exist_ok=True)
+
+        state = {
+            "model_name": self.model_name,
+            "embedding_dim": self.embedding_dim,
+            "device": self.device,
+            "using_sentence_transformer": self._using_sentence_transformer,
+            "clf": self.clf,
+            "is_fitted": self.is_fitted,
+        }
+        joblib.dump(state, path / "model_state.pkl")
+
+        if self._using_sentence_transformer:
+            encoder_dir = path / "encoder"
+            encoder_dir.mkdir(parents=True, exist_ok=True)
+            # sentence-transformers requires a directory to persist the encoder
+            self._encoder.save(str(encoder_dir))
+
+    @classmethod
+    def load(cls, path: str | Path) -> "ExplanationInducedModel":
+        path = Path(path)
+        state = joblib.load(path / "model_state.pkl")
+
+        obj = cls(
+            model_name=state["model_name"],
+            embedding_dim=state["embedding_dim"],
+            device=state.get("device"),
+        )
+
+        using_sentence_transformer = state.get("using_sentence_transformer", False)
+        if using_sentence_transformer and SentenceTransformer is not None:
+            encoder_dir = path / "encoder"
+            obj._encoder = SentenceTransformer(str(encoder_dir), device=obj.device)
+            obj._using_sentence_transformer = True
+        elif using_sentence_transformer and SentenceTransformer is None:
+            warnings.warn(
+                "sentence-transformers not available when loading; using hashing encoder.",
+                RuntimeWarning,
+            )
+            obj._encoder = _HashingSentenceEncoder(obj.embedding_dim)
+            obj._using_sentence_transformer = False
+        else:
+            obj._encoder = _HashingSentenceEncoder(obj.embedding_dim)
+            obj._using_sentence_transformer = False
+
+        obj.clf = state["clf"]
+        obj.is_fitted = state.get("is_fitted", False)
+        return obj

--- a/src/tools/lime_tool.py
+++ b/src/tools/lime_tool.py
@@ -1,9 +1,173 @@
 from __future__ import annotations
+
+from typing import Callable, Dict, Sequence
+
 import numpy as np
 
-def get_local_explanation(x: np.ndarray):
-    """Stub: returns local surrogate coefficients and a fake R^2."""
-    rng = np.random.default_rng(abs(int(np.sum(x)*1e6)) % (2**32))
-    w = rng.normal(0, 0.5, size=x.shape[0])
-    r2 = float(np.clip(rng.normal(0.7, 0.05), 0, 1))
-    return {"coefficients": w.tolist(), "r2": r2}
+try:  # pragma: no cover - exercised via optional dependency
+    from lime.lime_tabular import LimeTabularExplainer  # type: ignore
+except ImportError:  # pragma: no cover - deterministic fallback exercised in tests
+    LimeTabularExplainer = None
+
+PredictProbaFn = Callable[[np.ndarray], Sequence[Sequence[float]]]
+
+
+def make_lime_tool(
+    predict_proba: PredictProbaFn,
+    feature_names: Sequence[str] | None = None,
+    *,
+    training_data: np.ndarray | None = None,
+    n_samples: int = 500,
+    kernel_width: float | None = None,
+    random_state: int | None = None,
+) -> Callable[[np.ndarray], Dict[str, float | Sequence[float] | int | str]]:
+    """Create a LIME-style local explanation tool.
+
+    Parameters
+    ----------
+    predict_proba:
+        Callable that returns class probabilities for a batch of inputs.
+    feature_names:
+        Optional feature names to pass to the underlying explainer.
+    training_data:
+        Optional background data. When provided and the ``lime`` package is
+        available, the wrapper will use :class:`LimeTabularExplainer`.
+    n_samples:
+        Number of perturbations to sample around the input instance.
+    kernel_width:
+        Width of the exponential kernel weighting perturbations; if ``None`` a
+        heuristic based on the feature dimensionality is used.
+    random_state:
+        Optional integer seed ensuring deterministic behaviour.
+    """
+
+    background = _ensure_2d_array(training_data) if training_data is not None else None
+    base_seed = int(random_state) if random_state is not None else 0
+
+    def get_local_explanation(x: np.ndarray) -> Dict[str, float | Sequence[float] | int | str]:
+        sample = _ensure_1d_array(x)
+        probs = _call_predict(predict_proba, sample.reshape(1, -1))
+        target_class = int(np.argmax(probs[0]))
+        seed = (base_seed + _hash_array(sample)) % (2**32)
+
+        if background is not None and LimeTabularExplainer is not None:
+            explainer = LimeTabularExplainer(
+                training_data=background,
+                feature_names=list(feature_names) if feature_names is not None else None,
+                class_names=None,
+                discretize_continuous=False,
+                sample_around_instance=True,
+                random_state=seed,
+            )
+            explanation = explainer.explain_instance(
+                sample,
+                lambda data: _call_predict(predict_proba, data),
+                num_features=sample.size,
+                labels=[target_class],
+                num_samples=n_samples,
+            )
+            coefficients = np.zeros(sample.size, dtype=float)
+            for idx, weight in explanation.local_exp.get(target_class, []):
+                coefficients[int(idx)] = float(weight)
+            intercept = float(explanation.intercept[target_class])
+            r2 = float(explanation.score)
+            r2 = float(np.clip(r2, 0.0, 1.0))
+        else:
+            intercept, coefficients, r2 = _lime_via_local_linear(
+                predict_proba,
+                sample,
+                target_class,
+                seed,
+                n_samples=n_samples,
+                kernel_width=kernel_width,
+            )
+
+        return {
+            "method": "LIME",
+            "coefficients": coefficients.tolist(),
+            "intercept": float(intercept),
+            "r2": float(r2),
+            "target_class": target_class,
+        }
+
+    return get_local_explanation
+
+
+def _lime_via_local_linear(
+    predict_proba: PredictProbaFn,
+    sample: np.ndarray,
+    target_class: int,
+    seed: int,
+    *,
+    n_samples: int,
+    kernel_width: float | None,
+) -> tuple[float, np.ndarray, float]:
+    rng = np.random.default_rng(seed)
+    dim = sample.size
+    width = kernel_width if kernel_width is not None else np.sqrt(dim) * 0.75
+
+    scale = np.maximum(np.abs(sample), 1.0)
+    perturbations = rng.normal(loc=0.0, scale=scale, size=(n_samples, dim))
+    candidates = sample + perturbations
+
+    preds = _call_predict(predict_proba, candidates)[:, target_class]
+    distances = np.linalg.norm(candidates - sample, axis=1)
+    weights = np.exp(-(distances ** 2) / (width ** 2 + 1e-12))
+    weights = np.clip(weights, 1e-9, None)
+
+    design = np.hstack([np.ones((n_samples, 1)), candidates])
+    weighted_design = design * weights[:, None]
+    weighted_targets = preds * weights
+
+    beta, *_ = np.linalg.lstsq(weighted_design, weighted_targets, rcond=None)
+    intercept = float(beta[0])
+    coefficients = beta[1:].astype(float, copy=False)
+
+    fitted = design @ beta
+    target_mean = np.average(preds, weights=weights)
+    total_var = np.sum(weights * (preds - target_mean) ** 2)
+    if total_var <= 1e-12:
+        r2 = 0.0
+    else:
+        residual = preds - fitted
+        r2 = 1.0 - (np.sum(weights * residual**2) / total_var)
+    r2 = float(np.clip(r2, 0.0, 1.0))
+
+    return intercept, coefficients, r2
+
+
+def _call_predict(predict_proba: PredictProbaFn, data: np.ndarray) -> np.ndarray:
+    arr = np.asarray(predict_proba(np.asarray(data, dtype=float)))
+    if arr.ndim == 1:
+        arr = arr.reshape(-1, 1)
+    return arr
+
+
+def _ensure_1d_array(x: np.ndarray) -> np.ndarray:
+    arr = np.asarray(x, dtype=float)
+    if arr.ndim == 2 and arr.shape[0] == 1:
+        arr = arr.reshape(-1)
+    if arr.ndim != 1:
+        raise ValueError("Expected a 1-D feature vector")
+    return arr
+
+
+def _ensure_2d_array(x: np.ndarray | None) -> np.ndarray:
+    if x is None:
+        raise ValueError("training_data cannot be None when using this helper")
+    arr = np.asarray(x, dtype=float)
+    if arr.ndim == 1:
+        arr = arr.reshape(1, -1)
+    if arr.ndim != 2:
+        raise ValueError("Expected training_data to be a 2-D array")
+    return arr
+
+
+def _hash_array(arr: np.ndarray) -> int:
+    scaled = np.round(arr * 1e6).astype(np.int64, copy=False)
+    weights = np.arange(1, scaled.size + 1, dtype=np.int64)
+    hashed = int(np.abs(np.dot(scaled, weights)) % (2**32))
+    return hashed
+
+
+__all__ = ["make_lime_tool"]

--- a/src/tools/pdp_tool.py
+++ b/src/tools/pdp_tool.py
@@ -1,9 +1,111 @@
 from __future__ import annotations
+
+from typing import Callable, Dict
+
 import numpy as np
 
-def get_partial_dependence(x: np.ndarray, feature_i: int, grid_points: int = 10):
-    """Stub PDP: returns a monotone curve if feature value is large, else flat-ish."""
-    xi = float(x[feature_i])
-    grid = np.linspace(xi - 1.0, xi + 1.0, grid_points)
-    curve = 1 / (1 + np.exp(-grid))  # logistic-shaped
-    return {"feature": int(feature_i), "grid": grid.tolist(), "pdp": curve.tolist()}
+PredictProbaFn = Callable[[np.ndarray], np.ndarray]
+
+
+def make_pdp_tool(
+    predict_proba: PredictProbaFn,
+    feature_grid: Dict[int, np.ndarray],
+    *,
+    background: np.ndarray | None = None,
+) -> Callable[[np.ndarray, int], Dict[str, object]]:
+    """Create a partial dependence (or ICE) tool bound to ``predict_proba``.
+
+    Parameters
+    ----------
+    predict_proba:
+        Callable returning probabilities for a batch of inputs.
+    feature_grid:
+        Mapping from feature indices to 1-D arrays defining the evaluation grid.
+    background:
+        Optional background dataset used when averaging PDP curves. When ``None``
+        the PDP defaults to the ICE curve for the queried instance.
+    """
+
+    processed_grid = {_ensure_int(idx): _ensure_grid(values) for idx, values in feature_grid.items()}
+    background_array = _ensure_2d(background) if background is not None else None
+
+    def get_partial_dependence(x: np.ndarray, feature_i: int) -> Dict[str, object]:
+        sample = _ensure_1d(x)
+        feature_idx = _ensure_int(feature_i)
+        if feature_idx not in processed_grid:
+            raise KeyError(f"No grid specified for feature index {feature_idx}")
+
+        grid_values = processed_grid[feature_idx]
+        base_probs = _call_predict(predict_proba, sample.reshape(1, -1))
+        target_class = int(np.argmax(base_probs[0]))
+
+        pdp_base = background_array if background_array is not None else sample.reshape(1, -1)
+
+        pdp_curve = np.zeros(grid_values.size, dtype=float)
+        for position, grid_value in enumerate(grid_values):
+            evaluation = np.array(pdp_base, copy=True)
+            evaluation[:, feature_idx] = grid_value
+            probs = _call_predict(predict_proba, evaluation)[:, target_class]
+            pdp_curve[position] = float(np.mean(probs))
+
+        ice_points = np.repeat(sample.reshape(1, -1), grid_values.size, axis=0)
+        ice_points[:, feature_idx] = grid_values
+        ice_curve = _call_predict(predict_proba, ice_points)[:, target_class]
+
+        return {
+            "method": "PDP",
+            "feature": feature_idx,
+            "target_class": target_class,
+            "grid": grid_values.tolist(),
+            "pdp": pdp_curve.tolist(),
+            "ice": ice_curve.tolist(),
+        }
+
+    return get_partial_dependence
+
+
+def _call_predict(predict_proba: PredictProbaFn, data: np.ndarray) -> np.ndarray:
+    arr = np.asarray(predict_proba(np.asarray(data, dtype=float)))
+    if arr.ndim == 1:
+        arr = arr.reshape(-1, 1)
+    return arr
+
+
+def _ensure_grid(values: np.ndarray) -> np.ndarray:
+    arr = np.asarray(values, dtype=float)
+    if arr.ndim != 1:
+        raise ValueError("Grid values must be a 1-D array")
+    if arr.size == 0:
+        raise ValueError("Grid for partial dependence cannot be empty")
+    return arr
+
+
+def _ensure_1d(x: np.ndarray) -> np.ndarray:
+    arr = np.asarray(x, dtype=float)
+    if arr.ndim == 1:
+        return arr
+    if arr.ndim == 2 and arr.shape[0] == 1:
+        return arr.reshape(-1)
+    raise ValueError("x must be a 1-D feature vector")
+
+
+def _ensure_2d(x: np.ndarray | None) -> np.ndarray:
+    if x is None:
+        raise ValueError("background cannot be None when using this helper")
+    arr = np.asarray(x, dtype=float)
+    if arr.ndim == 1:
+        arr = arr.reshape(1, -1)
+    if arr.ndim != 2:
+        raise ValueError("background must be a 2-D array")
+    return arr
+
+
+def _ensure_int(value: int) -> int:
+    if isinstance(value, (np.integer,)):
+        return int(value)
+    if not isinstance(value, (int,)):
+        raise TypeError("Feature indices must be integers")
+    return int(value)
+
+
+__all__ = ["make_pdp_tool"]

--- a/src/tools/shap_tool.py
+++ b/src/tools/shap_tool.py
@@ -1,9 +1,210 @@
 from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, List, Sequence, Tuple
+
 import numpy as np
 
-def get_feature_importance(x: np.ndarray, top_k: int = 3):
-    """Stub: returns signed magnitudes that sum to zero-ish for interpretability demos."""
-    rng = np.random.default_rng(abs(int(np.sum(x)*1e6)) % (2**32))
-    vals = rng.normal(0, 1, size=x.shape[0])
-    order = np.argsort(-np.abs(vals))[:top_k]
-    return [(int(i), float(vals[i])) for i in order]
+try:  # pragma: no cover - exercised via optional dependency
+    import shap  # type: ignore
+except ImportError:  # pragma: no cover - handled with deterministic fallback
+    shap = None
+
+
+PredictProbaFn = Callable[[np.ndarray], Sequence[Sequence[float]]]
+
+
+@dataclass(frozen=True)
+class _ExplainerBundle:
+    shap_values_fn: Callable[[np.ndarray], np.ndarray]
+    background: np.ndarray
+
+
+def make_shap_tool(
+    predict_proba: PredictProbaFn,
+    background_X: np.ndarray,
+    *,
+    max_background: int = 50,
+) -> Callable[[np.ndarray, int], List[Tuple[int, float]]]:
+    """Create a SHAP-based feature-importance tool.
+
+    Parameters
+    ----------
+    predict_proba:
+        Callable mapping a 2-D ``numpy.ndarray`` of shape ``(n_samples, n_features)`` to
+        probabilities. Typically ``model.predict_proba``.
+    background_X:
+        Background data used to initialise the explainer or to compute fallbacks.
+    max_background:
+        Maximum number of background rows kept for explainers that do not scale
+        well with dataset size.
+    """
+
+    background = _ensure_2d_array(background_X)
+    if background.shape[0] == 0:
+        raise ValueError("background_X must contain at least one row")
+
+    if max_background < 1:
+        raise ValueError("max_background must be at least 1")
+
+    background_subset = background[:max_background]
+    explainer = _build_explainer_bundle(predict_proba, background_subset)
+
+    def get_feature_importance(x: np.ndarray, top_k: int = 3) -> List[Tuple[int, float]]:
+        if top_k < 1:
+            raise ValueError("top_k must be at least 1")
+
+        sample = _ensure_2d_array(x)
+        if sample.shape[1] != background.shape[1]:
+            raise ValueError("x dimensionality does not match background data")
+
+        shap_values = explainer.shap_values_fn(sample)
+        shap_values = np.asarray(shap_values, dtype=float)
+        if shap_values.ndim != 2 or shap_values.shape[0] != sample.shape[0]:
+            raise ValueError("Unexpected SHAP output shape")
+
+        values = shap_values[0]
+        order = np.argsort(-np.abs(values))[: min(top_k, values.shape[0])]
+        return [(int(i), float(values[i])) for i in order]
+
+    return get_feature_importance
+
+
+def _build_explainer_bundle(
+    predict_proba: PredictProbaFn,
+    background: np.ndarray,
+) -> _ExplainerBundle:
+    if shap is None:
+        return _ExplainerBundle(
+            shap_values_fn=lambda x: _approximate_shap(predict_proba, background, x),
+            background=background,
+        )
+
+    model = getattr(predict_proba, "__self__", None)
+    model_kind = _infer_model_kind(model)
+
+    if model is not None and model_kind == "tree":
+        explainer = shap.TreeExplainer(model, data=background)  # type: ignore[attr-defined]
+
+        def tree_values(x: np.ndarray) -> np.ndarray:
+            raw = explainer.shap_values(x)
+            return _extract_shap_values(raw, predict_proba, x)
+
+        return _ExplainerBundle(shap_values_fn=tree_values, background=background)
+
+    if model is not None and model_kind == "linear":
+        try:
+            explainer = shap.LinearExplainer(model, background, link="logit")  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover - older SHAP versions fall back to defaults
+            explainer = shap.LinearExplainer(model, background)  # type: ignore[attr-defined]
+
+        def linear_values(x: np.ndarray) -> np.ndarray:
+            raw = explainer.shap_values(x)
+            return _extract_shap_values(raw, predict_proba, x)
+
+        return _ExplainerBundle(shap_values_fn=linear_values, background=background)
+
+    kernel_background = background[: min(20, background.shape[0])]
+    kernel_explainer = shap.KernelExplainer(  # type: ignore[attr-defined]
+        lambda data: _call_predict(predict_proba, data),
+        kernel_background,
+    )
+
+    def kernel_values(x: np.ndarray) -> np.ndarray:
+        raw = kernel_explainer.shap_values(x)
+        return _extract_shap_values(raw, predict_proba, x)
+
+    return _ExplainerBundle(shap_values_fn=kernel_values, background=background)
+
+
+def _approximate_shap(
+    predict_proba: PredictProbaFn,
+    background: np.ndarray,
+    x: np.ndarray,
+) -> np.ndarray:
+    sample = _ensure_2d_array(x)
+    preds = _call_predict(predict_proba, sample)
+    baseline_preds = _call_predict(predict_proba, background)
+
+    target_class = int(np.argmax(preds[0]))
+    baseline_prob = float(np.mean(baseline_preds[:, target_class]))
+    target_prob = float(preds[0, target_class])
+
+    diffs = np.zeros(sample.shape[1], dtype=float)
+    for idx in range(sample.shape[1]):
+        substituted = np.array(background, copy=True)
+        substituted[:, idx] = sample[0, idx]
+        substituted_preds = _call_predict(predict_proba, substituted)
+        diffs[idx] = float(np.mean(substituted_preds[:, target_class]) - baseline_prob)
+
+    total = diffs.sum()
+    desired_total = target_prob - baseline_prob
+    if np.isfinite(total) and abs(total) > 1e-9:
+        diffs *= desired_total / total
+    else:
+        diffs[:] = desired_total / sample.shape[1]
+
+    return diffs.reshape(1, -1)
+
+
+def _extract_shap_values(raw_values: Iterable, predict_proba: PredictProbaFn, x: np.ndarray) -> np.ndarray:
+    values = raw_values
+
+    if hasattr(values, "values"):
+        values = getattr(values, "values")  # shap.Explanation
+
+    if isinstance(values, list):
+        arrays = [np.asarray(v, dtype=float) for v in values]
+        probs = _call_predict(predict_proba, x)
+        target_class = int(np.argmax(probs[0]))
+        selected = arrays[target_class]
+        if selected.ndim == 1:
+            return selected.reshape(1, -1)
+        return np.asarray(selected, dtype=float)
+
+    array = np.asarray(values, dtype=float)
+    if array.ndim == 1:
+        return array.reshape(1, -1)
+    if array.ndim == 2:
+        return array
+    if array.ndim == 3:
+        probs = _call_predict(predict_proba, x)
+        target_class = int(np.argmax(probs[0]))
+        return array[:, target_class, :]
+
+    raise ValueError("Unable to interpret SHAP output shape")
+
+
+def _call_predict(predict_proba: PredictProbaFn, data: np.ndarray) -> np.ndarray:
+    arr = np.asarray(predict_proba(np.asarray(data, dtype=float)))
+    if arr.ndim == 1:
+        arr = arr.reshape(-1, 1)
+    return arr
+
+
+def _infer_model_kind(model: object | None) -> str:
+    if model is None:
+        return "unknown"
+    module = getattr(model.__class__, "__module__", "").lower()
+    name = getattr(model.__class__, "__name__", "").lower()
+
+    tree_tokens = ("tree", "forest", "boost", "gbm", "gb", "catboost", "xgboost")
+    linear_tokens = ("linear", "logistic", "ridge", "lasso", "sgd")
+
+    if any(token in module or token in name for token in tree_tokens):
+        return "tree"
+    if any(token in module or token in name for token in linear_tokens):
+        return "linear"
+    return "unknown"
+
+
+def _ensure_2d_array(x: np.ndarray) -> np.ndarray:
+    arr = np.asarray(x, dtype=float)
+    if arr.ndim == 1:
+        arr = arr.reshape(1, -1)
+    if arr.ndim != 2:
+        raise ValueError("Expected a 1-D or 2-D array")
+    return arr
+
+
+__all__ = ["make_shap_tool"]

--- a/src/training/train_ppo.py
+++ b/src/training/train_ppo.py
@@ -1,26 +1,525 @@
 from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import warnings
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence, Tuple
+
 import numpy as np
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+
+from src.data.datasets import TabularDataset
 from src.envs.explain_env import ExplainEnv
-from src.agents.agent_langchain import ToolUsingPolicy
-from src.tools.shap_tool import get_feature_importance
-from src.tools.lime_tool import get_local_explanation
-from src.tools.pdp_tool import get_partial_dependence
+from src.models.blackbox import BlackBoxModel
 
-def run_random_policy(n_episodes: int = 5):
-    env = ExplainEnv(n_features=10, seed=0)
-    tools = {
-        "get_feature_importance": get_feature_importance,
-        "get_local_explanation": get_local_explanation,
-        "get_partial_dependence": get_partial_dependence,
+try:  # Optional torch / transformers / trl stack
+    import torch
+except Exception:  # pragma: no cover - torch not available in minimal envs
+    torch = None  # type: ignore
+
+try:  # pragma: no cover - transformers optional
+    from transformers import AutoTokenizer
+except Exception:  # pragma: no cover
+    AutoTokenizer = None  # type: ignore
+
+try:  # pragma: no cover - trl optional
+    from trl import AutoModelForCausalLMWithValueHead, PPOConfig, PPOTrainer
+except Exception:  # pragma: no cover
+    AutoModelForCausalLMWithValueHead = None  # type: ignore
+    PPOConfig = None  # type: ignore
+    PPOTrainer = None  # type: ignore
+
+
+def _ensure_logging() -> None:
+    if not logging.getLogger().handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="[%(asctime)s] %(levelname)s - %(message)s",
+            stream=sys.stdout,
+        )
+
+
+def set_seed(seed: int) -> None:
+    np.random.seed(seed)
+    try:  # pragma: no cover - random imported lazily
+        import random
+
+        random.seed(seed)
+    except Exception:  # pragma: no cover
+        pass
+
+    if torch is not None:
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():  # pragma: no cover - GPU CI unlikely
+            torch.cuda.manual_seed_all(seed)
+
+
+def format_prompt(x: np.ndarray, p: np.ndarray) -> str:
+    x_str = ", ".join(f"{xi:.3f}" for xi in x)
+    p_str = ", ".join(f"{pi:.3f}" for pi in p)
+    return (
+        "You are an explanation agent. Given features x and model predictions p, "
+        "produce a plain language explanation.\n"
+        f"x = [{x_str}]\n"
+        f"p = [{p_str}]\n"
+        "Explanation:"
+    )
+
+
+def _build_default_dataset(
+    seed: int,
+    n_features: int = 10,
+    dataset_size: int = 128,
+) -> tuple[TabularDataset, BlackBoxModel]:
+    X, y = make_classification(
+        n_samples=dataset_size,
+        n_features=n_features,
+        n_informative=min(6, n_features),
+        n_redundant=min(2, max(n_features - 6, 0)),
+        n_classes=2,
+        random_state=seed,
+    )
+    dataset = TabularDataset.from_arrays(X, y, feature_names=None)
+    blackbox = BlackBoxModel.from_training(
+        dataset=dataset,
+        estimator_factory=lambda: LogisticRegression(max_iter=1000, random_state=seed),
+    )
+    return dataset, blackbox
+
+
+def _to_float(value: object, default: float = float("nan")) -> float:
+    if isinstance(value, (float, int)):
+        return float(value)
+    if torch is not None and isinstance(value, torch.Tensor):  # pragma: no cover - torch optional
+        if value.numel() == 0:
+            return default
+        return float(value.detach().float().cpu().item())
+    if isinstance(value, (list, tuple)) and value:
+        return _to_float(value[0], default)
+    if hasattr(value, "item"):
+        try:
+            return float(value.item())
+        except Exception:  # pragma: no cover
+            return default
+    return default
+
+
+def _extract_stat(stats: Dict[str, object], keys: Sequence[str], default: float = float("nan")) -> float:
+    for key in keys:
+        if key in stats:
+            return _to_float(stats[key], default)
+    return default
+
+
+class DummyTokenizer:
+    pad_token_id: int = 0
+    eos_token_id: int = 1
+
+    def __init__(self) -> None:
+        self._offset = 2
+
+    def encode(self, text: str) -> List[int]:
+        return [self._offset + (ord(ch) % 256) for ch in text]
+
+    def decode(self, tokens: Iterable[int], skip_special_tokens: bool = True) -> str:
+        chars = []
+        for token in tokens:
+            if skip_special_tokens and token in (self.pad_token_id, self.eos_token_id):
+                continue
+            chars.append(chr((int(token) - self._offset) % 256))
+        return "".join(chars)
+
+    def batch_decode(self, sequences: Sequence[Sequence[int]], skip_special_tokens: bool = True) -> List[str]:
+        return [self.decode(seq, skip_special_tokens=skip_special_tokens) for seq in sequences]
+
+    def __call__(self, texts: Sequence[str] | str, return_tensors: str | None = None, padding: bool = False):
+        if isinstance(texts, str):
+            texts = [texts]
+        encoded = [self.encode(t) for t in texts]
+        max_len = max((len(e) for e in encoded), default=0)
+        arrs = []
+        for e in encoded:
+            sequence = list(e)
+            if return_tensors == "pt" and torch is not None:
+                tensor = torch.tensor(sequence, dtype=torch.long)
+                if padding:
+                    pad_len = max_len - len(sequence)
+                    if pad_len > 0:
+                        tensor = torch.cat([
+                            tensor,
+                            torch.full((pad_len,), self.pad_token_id, dtype=torch.long),
+                        ])
+                arrs.append(tensor)
+            else:
+                if padding:
+                    pad_len = max_len - len(sequence)
+                    if pad_len > 0:
+                        sequence = sequence + [self.pad_token_id] * pad_len
+                arrs.append(sequence)
+        if return_tensors == "pt" and torch is not None:
+            input_ids = torch.stack(arrs) if arrs else torch.empty((0, 0), dtype=torch.long)
+            attention_mask = (input_ids != self.pad_token_id).long()
+            return {"input_ids": input_ids, "attention_mask": attention_mask}
+        return {"input_ids": arrs, "attention_mask": [[1] * len(seq) for seq in arrs]}
+
+
+class DummyValueHeadModel:
+    def __init__(self, tokenizer: DummyTokenizer, seed: int = 0) -> None:
+        self.tokenizer = tokenizer
+        self.rng = np.random.default_rng(seed)
+        self._vocab = [
+            "evidence",
+            "suggests",
+            "feature",
+            "impact",
+            "class",
+            "because",
+            "low",
+            "high",
+            "risk",
+            "signal",
+        ]
+
+    def generate_text(self, prompt: str, max_new_tokens: int) -> Tuple[List[int], List[int], str]:
+        query_tokens = self.tokenizer.encode(prompt)
+        length = int(self.rng.integers(1, max(2, max_new_tokens + 1)))
+        words = [self.rng.choice(self._vocab) for _ in range(length)]
+        response_text = " ".join(words)
+        response_tokens = self.tokenizer.encode(response_text) + [self.tokenizer.eos_token_id]
+        return query_tokens, response_tokens, response_text
+
+    # mimic torch API used in code paths
+    def to(self, *_args, **_kwargs) -> "DummyValueHeadModel":
+        return self
+
+    def eval(self) -> "DummyValueHeadModel":
+        return self
+
+    def train(self) -> "DummyValueHeadModel":  # pragma: no cover - no-op
+        return self
+
+
+class DummyPPOTrainer:
+    def __init__(self, model: DummyValueHeadModel, tokenizer: DummyTokenizer, target_kl: float, lr: float, grad_accumulation_steps: int) -> None:
+        self.model = model
+        self.tokenizer = tokenizer
+        self.target_kl = target_kl
+        self.lr = lr
+        self.grad_accumulation_steps = grad_accumulation_steps
+        self._step = 0
+
+    def step(self, queries: Sequence[Sequence[int]], responses: Sequence[Sequence[int]], rewards: Sequence[float]) -> Dict[str, float]:
+        self._step += 1
+        mean_reward = float(np.mean(rewards)) if rewards else 0.0
+        # Construct simple proxies for KL metrics so logs remain meaningful.
+        avg_response_tokens = float(np.mean([len(r) for r in responses])) if responses else 0.0
+        kl = avg_response_tokens / 100.0
+        ref_kl = kl / 2.0
+        return {
+            "kl": kl,
+            "ref_kl": ref_kl,
+            "mean_reward": mean_reward,
+            "learning_rate": self.lr,
+            "target_kl": self.target_kl,
+        }
+
+
+@dataclass
+class PPOTrainingConfig:
+    model_name: str = "dummy"
+    batch_size: int = 2
+    rollout_steps: int = 2
+    lr: float = 1e-5
+    target_kl: float = 0.1
+    seed: int = 0
+    max_new_tokens: int = 32
+    grad_accumulation_steps: int = 1
+
+
+def _init_real_trl_stack(cfg: PPOTrainingConfig):  # pragma: no cover - depends on optional deps
+    assert torch is not None
+    assert AutoTokenizer is not None
+    assert AutoModelForCausalLMWithValueHead is not None
+    assert PPOConfig is not None and PPOTrainer is not None
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    tokenizer = AutoTokenizer.from_pretrained(cfg.model_name)
+    if tokenizer.pad_token is None and tokenizer.eos_token is not None:
+        tokenizer.pad_token = tokenizer.eos_token
+    elif tokenizer.pad_token is None:
+        tokenizer.add_special_tokens({"pad_token": "<|pad|>"})
+
+    model_kwargs = {}
+    if torch.cuda.is_available():
+        model_kwargs["torch_dtype"] = torch.float16
+
+    model = AutoModelForCausalLMWithValueHead.from_pretrained(cfg.model_name, **model_kwargs)
+    model.to(device)
+    ref_model = AutoModelForCausalLMWithValueHead.from_pretrained(cfg.model_name, **model_kwargs)
+    ref_model.to(device)
+    ref_model.eval()
+    for param in ref_model.parameters():
+        param.requires_grad_(False)
+
+    config_kwargs = {
+        "model_name": cfg.model_name,
+        "learning_rate": cfg.lr,
+        "batch_size": cfg.batch_size,
+        "mini_batch_size": max(1, cfg.batch_size // cfg.grad_accumulation_steps),
+        "target_kl": cfg.target_kl,
     }
-    policy = ToolUsingPolicy(tools=tools, seed=0)
+    try:
+        ppo_config = PPOConfig(
+            **config_kwargs,
+            gradient_accumulation_steps=cfg.grad_accumulation_steps,
+        )
+    except TypeError:
+        ppo_config = PPOConfig(**config_kwargs)
+        if hasattr(ppo_config, "gradient_accumulation_steps"):
+            setattr(ppo_config, "gradient_accumulation_steps", cfg.grad_accumulation_steps)
 
-    for ep in range(n_episodes):
-        obs = env.reset()
-        x, p = obs["x"], obs["p"]
-        explanation = policy.generate_explanation(x, p)
-        step_out = env.step(explanation)
-        print(f"Episode {ep}: R={step_out.reward:.4f} | q={step_out.observation['q']}\nE: {explanation}\n")
+    trainer = PPOTrainer(ppo_config, model, ref_model=ref_model, tokenizer=tokenizer)
+    return trainer, tokenizer, device
+
+
+def _init_dummy_stack(cfg: PPOTrainingConfig) -> Tuple[DummyPPOTrainer, DummyTokenizer, None]:
+    warnings.warn(
+        "transformers/trl not available - falling back to dummy PPO components."
+    )
+    tokenizer = DummyTokenizer()
+    model = DummyValueHeadModel(tokenizer, seed=cfg.seed)
+    trainer = DummyPPOTrainer(model=model, tokenizer=tokenizer, target_kl=cfg.target_kl, lr=cfg.lr, grad_accumulation_steps=cfg.grad_accumulation_steps)
+    return trainer, tokenizer, None
+
+
+def initialize_trainer(cfg: PPOTrainingConfig):
+    have_trl = (
+        torch is not None
+        and AutoTokenizer is not None
+        and AutoModelForCausalLMWithValueHead is not None
+        and PPOConfig is not None
+        and PPOTrainer is not None
+    )
+    if not have_trl:
+        return _init_dummy_stack(cfg)
+    try:
+        return _init_real_trl_stack(cfg)
+    except Exception as exc:  # pragma: no cover - best effort fallback
+        warnings.warn(f"Falling back to dummy PPO stack due to: {exc}")
+        return _init_dummy_stack(cfg)
+
+
+def _sample_with_dummy(
+    model: DummyValueHeadModel,
+    tokenizer: DummyTokenizer,
+    prompts: Sequence[str],
+    max_new_tokens: int,
+) -> Tuple[List[List[int]], List[List[int]], List[str], List[int], List[int]]:
+    query_tensors: List[List[int]] = []
+    response_tensors: List[List[int]] = []
+    response_texts: List[str] = []
+    prompt_lens: List[int] = []
+    response_lens: List[int] = []
+    for prompt in prompts:
+        query_tokens, response_tokens, response_text = model.generate_text(prompt, max_new_tokens)
+        query_tensors.append(query_tokens)
+        response_tensors.append(response_tokens)
+        response_texts.append(response_text)
+        prompt_lens.append(len(query_tokens))
+        response_lens.append(len(response_tokens))
+    return query_tensors, response_tensors, response_texts, prompt_lens, response_lens
+
+
+def _sample_with_trl(
+    trainer,
+    tokenizer,
+    prompts: Sequence[str],
+    device,
+    max_new_tokens: int,
+):  # pragma: no cover - depends on optional deps
+    query_tensors: List[torch.Tensor] = []
+    response_tensors: List[torch.Tensor] = []
+    response_texts: List[str] = []
+    prompt_lens: List[int] = []
+    response_lens: List[int] = []
+
+    pad_token_id = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id
+
+    for prompt in prompts:
+        encoded = tokenizer(prompt, return_tensors="pt")
+        input_ids = encoded["input_ids"].to(device)
+        attention_mask = encoded.get("attention_mask")
+        if attention_mask is not None:
+            attention_mask = attention_mask.to(device)
+        prompt_len = input_ids.shape[-1]
+
+        policy_model = getattr(trainer, "model", trainer)
+        generate_kwargs = {
+            "max_new_tokens": max_new_tokens,
+            "do_sample": True,
+        }
+        if pad_token_id is not None:
+            generate_kwargs["pad_token_id"] = pad_token_id
+
+        with torch.no_grad():
+            output = policy_model.generate(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                **generate_kwargs,
+            )
+
+        generated = output[0, prompt_len:]
+        if generated.numel() == 0:
+            filler = pad_token_id if pad_token_id is not None else 0
+            generated = torch.tensor([filler], device=device)
+
+        query_tensors.append(input_ids.squeeze(0))
+        response_tensors.append(generated)
+        prompt_lens.append(int(prompt_len))
+        response_lens.append(int(generated.shape[-1]))
+        response_text = tokenizer.decode(generated.detach().cpu().tolist(), skip_special_tokens=True)
+        response_texts.append(response_text)
+
+    return query_tensors, response_tensors, response_texts, prompt_lens, response_lens
+
+
+def sample_model_responses(
+    trainer,
+    tokenizer,
+    prompts: Sequence[str],
+    device,
+    max_new_tokens: int,
+):
+    if isinstance(trainer, DummyPPOTrainer):
+        return _sample_with_dummy(trainer.model, tokenizer, prompts, max_new_tokens)
+    return _sample_with_trl(trainer, tokenizer, prompts, device, max_new_tokens)
+
+
+def _convert_rewards(rewards: Sequence[float], device, use_torch: bool):
+    if not use_torch:
+        return list(rewards)
+    tensors: List[torch.Tensor] = []
+    for r in rewards:
+        tensor = torch.tensor([r], dtype=torch.float32, device=device)
+        tensors.append(tensor)
+    return tensors
+
+
+def train(cfg: PPOTrainingConfig) -> List[Dict[str, float]]:
+    _ensure_logging()
+    set_seed(cfg.seed)
+
+    trainer, tokenizer, device = initialize_trainer(cfg)
+    use_torch = torch is not None and not isinstance(trainer, DummyPPOTrainer)
+
+    dataset, blackbox = _build_default_dataset(seed=cfg.seed)
+    env = ExplainEnv(dataset=dataset, blackbox=blackbox, seed=cfg.seed)
+    stats_history: List[Dict[str, float]] = []
+
+    buffer_queries = []
+    buffer_responses = []
+    buffer_rewards = []
+    buffer_prompt_lens: List[int] = []
+    buffer_response_lens: List[int] = []
+
+    def flush_buffers(step_idx: int) -> None:
+        if not buffer_queries:
+            return
+        batch_queries = list(buffer_queries)
+        batch_responses = list(buffer_responses)
+        batch_rewards = list(buffer_rewards)
+        batch_prompt_lens = list(buffer_prompt_lens)
+        batch_response_lens = list(buffer_response_lens)
+
+        rewards_tensor = _convert_rewards(batch_rewards, device, use_torch)
+        train_stats = trainer.step(batch_queries, batch_responses, rewards_tensor)
+        stats_history.append({k: _to_float(v) for k, v in train_stats.items()})
+
+        kl = _extract_stat(train_stats, ["kl", "ppo/kl", "objective/kl"])
+        ref_kl = _extract_stat(train_stats, ["ref_kl", "ppo/ref_kl", "objective/ref_kl"])
+        mean_reward = float(np.mean(batch_rewards)) if batch_rewards else float("nan")
+        prompt_tokens = float(np.mean(batch_prompt_lens)) if batch_prompt_lens else 0.0
+        response_tokens = float(np.mean(batch_response_lens)) if batch_response_lens else 0.0
+
+        logging.info(
+            "update=%d | mean_reward=%.4f | kl=%.4f | ref_kl=%.4f | prompt_tokens=%.2f | response_tokens=%.2f",
+            step_idx,
+            mean_reward,
+            kl,
+            ref_kl,
+            prompt_tokens,
+            response_tokens,
+        )
+
+        buffer_queries.clear()
+        buffer_responses.clear()
+        buffer_rewards.clear()
+        buffer_prompt_lens.clear()
+        buffer_response_lens.clear()
+
+    for rollout_idx in range(cfg.rollout_steps):
+        prompts: List[str] = []
+        for _ in range(cfg.batch_size):
+            obs = env.reset()
+            prompt_text = format_prompt(obs["x"], obs["p"])
+            prompts.append(prompt_text)
+
+        queries, responses, responses_text, prompt_lens, response_lens = sample_model_responses(
+            trainer,
+            tokenizer,
+            prompts,
+            device,
+            cfg.max_new_tokens,
+        )
+
+        rewards: List[float] = []
+        for response_text in responses_text:
+            step_out = env.step(response_text)
+            rewards.append(float(step_out.reward))
+
+        buffer_queries.extend(queries)
+        buffer_responses.extend(responses)
+        buffer_rewards.extend(rewards)
+        buffer_prompt_lens.extend(prompt_lens)
+        buffer_response_lens.extend(response_lens)
+
+        if (rollout_idx + 1) % max(1, cfg.grad_accumulation_steps) == 0:
+            flush_buffers(rollout_idx + 1)
+
+    flush_buffers(cfg.rollout_steps)
+
+    return stats_history
+
+
+def parse_args(argv: Sequence[str] | None = None) -> PPOTrainingConfig:
+    parser = argparse.ArgumentParser(description="Train PPO on ExplainEnv")
+    parser.add_argument("--model_name", type=str, default="dummy")
+    parser.add_argument("--batch_size", type=int, default=2)
+    parser.add_argument("--rollout_steps", type=int, default=4)
+    parser.add_argument("--lr", type=float, default=1e-5)
+    parser.add_argument("--target_kl", type=float, default=0.1)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--max_new_tokens", type=int, default=32)
+    parser.add_argument("--grad_accumulation_steps", type=int, default=1)
+    args = parser.parse_args(args=argv)
+    return PPOTrainingConfig(
+        model_name=args.model_name,
+        batch_size=args.batch_size,
+        rollout_steps=args.rollout_steps,
+        lr=args.lr,
+        target_kl=args.target_kl,
+        seed=args.seed,
+        max_new_tokens=args.max_new_tokens,
+        grad_accumulation_steps=max(1, args.grad_accumulation_steps),
+    )
+
 
 if __name__ == "__main__":
-    run_random_policy()
+    config = parse_args(None)
+    history = train(config)
+    if history:
+        last_stats = history[-1]
+        logging.info("Final stats: %s", {k: round(v, 4) for k, v in last_stats.items()})

--- a/tests/test_agent_langchain.py
+++ b/tests/test_agent_langchain.py
@@ -1,0 +1,142 @@
+import importlib
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:  # pragma: no cover - import-time path setup
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def _install_langchain_stubs(monkeypatch):
+    langchain_core = types.ModuleType("langchain_core")
+
+    language_models = types.ModuleType("langchain_core.language_models")
+
+    class BaseLanguageModel:  # pragma: no cover - simple stub
+        def invoke(self, *_args, **_kwargs):
+            raise NotImplementedError
+
+    language_models.BaseLanguageModel = BaseLanguageModel
+
+    messages = types.ModuleType("langchain_core.messages")
+
+    class _BaseMessage:  # pragma: no cover - simple stub
+        def __init__(self, content: str):
+            self.content = content
+
+    class AIMessage(_BaseMessage):
+        pass
+
+    class HumanMessage(_BaseMessage):
+        pass
+
+    messages.AIMessage = AIMessage
+    messages.HumanMessage = HumanMessage
+
+    langchain_core.language_models = language_models
+    langchain_core.messages = messages
+
+    monkeypatch.setitem(sys.modules, "langchain_core", langchain_core)
+    monkeypatch.setitem(sys.modules, "langchain_core.language_models", language_models)
+    monkeypatch.setitem(sys.modules, "langchain_core.messages", messages)
+
+    return language_models, messages
+
+
+def _module_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "src" / "agents" / "agent_langchain.py"
+
+
+def test_policy_requires_langchain(monkeypatch):
+    # Ensure LangChain is absent.
+    for key in list(sys.modules):
+        if key.startswith("langchain_core"):
+            monkeypatch.delitem(sys.modules, key, raising=False)
+
+    module_name = "agent_langchain_no_dependency"
+    spec = importlib.util.spec_from_file_location(module_name, _module_path())
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+
+    tools = {
+        "get_feature_importance": lambda **_: [],
+        "get_local_explanation": lambda **_: {},
+        "get_partial_dependence": lambda **_: {},
+    }
+
+    with pytest.raises(ImportError):
+        module.ToolUsingPolicy(tools=tools, llm=object())
+
+
+def test_policy_generates_cited_summary(monkeypatch):
+    language_models, messages = _install_langchain_stubs(monkeypatch)
+
+    module = importlib.import_module("src.agents.agent_langchain")
+    importlib.reload(module)
+
+    class DummyLLM(language_models.BaseLanguageModel):
+        def __init__(self, scripted_steps):
+            self._scripted_steps = scripted_steps
+            self._calls = 0
+
+        def invoke(self, _messages, **_kwargs):
+            if self._calls >= len(self._scripted_steps):
+                raise RuntimeError("LLM received more invocations than scripted")
+            payload = json.dumps(self._scripted_steps[self._calls])
+            self._calls += 1
+            return messages.AIMessage(payload)
+
+    shap_calls = []
+    local_calls = []
+    pdp_calls = []
+
+    def feature_tool(x):
+        shap_calls.append(x)
+        return [(0, 0.15), (2, -0.62), (1, 0.2)]
+
+    def local_tool(x):
+        local_calls.append(x)
+        return {"method": "LIME", "fidelity": 0.72}
+
+    def pdp_tool(x, feature_i):
+        pdp_calls.append((x, feature_i))
+        return {"trend": "monotone↑"}
+
+    scripted = [
+        {"thought": "Need feature attribution", "action": {"tool": "get_feature_importance", "args": {}}},
+        {"thought": "Check local explanation", "action": {"tool": "get_local_explanation", "args": {}}},
+        {"thought": "Study shape", "action": {"tool": "get_partial_dependence", "args": {"feature_i": 0}}},
+        {"thought": "Ready to summarise", "final": {}},
+    ]
+
+    llm = DummyLLM(scripted)
+    tools = {
+        "get_feature_importance": feature_tool,
+        "get_local_explanation": local_tool,
+        "get_partial_dependence": pdp_tool,
+    }
+
+    policy = module.ToolUsingPolicy(tools=tools, llm=llm, max_tool_calls=3)
+
+    x = np.array([0.1, -0.4, 1.2])
+    p = np.array([0.2, 0.8])
+    explanation = policy.generate_explanation(x, p)
+
+    assert shap_calls == [x.tolist()]
+    assert local_calls == [x.tolist()]
+    assert pdp_calls == [(x.tolist(), 2)]  # top feature is index 2 from SHAP values
+
+    assert "SHAP: f[2]" in explanation
+    assert "LIME fidelity=0.72" in explanation
+    assert "PDP@f2 monotone↑" in explanation
+    assert len(explanation.split()) <= 150
+

--- a/tests/test_blackbox_real.py
+++ b/tests/test_blackbox_real.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import numpy as np
+from sklearn.datasets import load_breast_cancer
+from sklearn.ensemble import RandomForestClassifier
+
+from src.data.datasets import TabularDataset
+from src.models.blackbox import BlackBoxModel
+
+
+def test_blackbox_from_sklearn_predicts_probabilities() -> None:
+    data = load_breast_cancer()
+    X, y = data.data, data.target
+    estimator = RandomForestClassifier(n_estimators=16, random_state=0)
+    estimator.fit(X, y)
+
+    model = BlackBoxModel.from_sklearn(estimator=estimator, n_features=X.shape[1])
+
+    proba = model.predict_proba(X[0])
+    assert proba.shape == (2,)
+    assert np.isfinite(proba).all()
+    assert np.isclose(proba.sum(), 1.0, atol=1e-6)
+
+
+def test_blackbox_from_training_wraps_estimator_factory() -> None:
+    data = load_breast_cancer()
+    dataset = TabularDataset.from_arrays(data.data, data.target, feature_names=list(data.feature_names))
+
+    def factory() -> RandomForestClassifier:
+        return RandomForestClassifier(n_estimators=8, random_state=0)
+
+    model = BlackBoxModel.from_training(dataset=dataset, estimator_factory=factory)
+
+    proba = model.predict_proba(dataset.X[:5])
+    assert proba.shape == (5, 2)
+    assert np.allclose(proba.sum(axis=1), 1.0, atol=1e-6)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pandas as pd
+from sklearn.datasets import load_breast_cancer
+
+from src.data.datasets import TabularDataset
+
+
+def test_tabular_dataset_from_arrays_and_sampling():
+    data = load_breast_cancer()
+    dataset = TabularDataset.from_arrays(data.data, data.target, list(data.feature_names))
+
+    assert dataset.n_features == data.data.shape[1]
+    samples = dataset.sample(n=5, seed=123)
+    assert samples.shape == (5, dataset.n_features)
+    assert np.all(np.isfinite(samples))
+
+    x, y = dataset.get_row(10)
+    assert x.shape == (dataset.n_features,)
+    assert y in {0, 1}
+
+    train_ds, val_ds, test_ds = dataset.split(seed=42)
+    assert sum(len(split) for split in (train_ds, val_ds, test_ds)) == len(dataset)
+    assert train_ds.feature_names == dataset.feature_names
+
+
+def test_tabular_dataset_from_dataframe():
+    data = load_breast_cancer()
+    df = pd.DataFrame(data.data, columns=data.feature_names)
+    df["label"] = data.target
+
+    dataset = TabularDataset.from_dataframe(df, label_col="label")
+    assert dataset.n_features == data.data.shape[1]
+    x, y = dataset.get_row(0)
+    assert x.shape == (dataset.n_features,)
+    assert y in {0, 1}

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,9 +1,75 @@
-from src.envs.explain_env import ExplainEnv
+import numpy as np
+import pytest
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
 
-def test_env_step_runs():
-    env = ExplainEnv(n_features=6, seed=42)
+from src.data.datasets import TabularDataset
+from src.envs.explain_env import ExplainEnv
+from src.models.blackbox import BlackBoxModel
+
+
+def _make_dataset_and_model(
+    *,
+    seed: int,
+    n_features: int = 10,
+    dataset_size: int = 64,
+) -> tuple[TabularDataset, BlackBoxModel]:
+    X, y = make_classification(
+        n_samples=dataset_size,
+        n_features=n_features,
+        n_informative=min(6, n_features),
+        n_redundant=min(2, max(n_features - 6, 0)),
+        n_classes=2,
+        random_state=seed,
+    )
+    dataset = TabularDataset.from_arrays(X, y, feature_names=None)
+    blackbox = BlackBoxModel.from_training(
+        dataset=dataset,
+        estimator_factory=lambda: LogisticRegression(max_iter=1000, random_state=seed),
+    )
+    return dataset, blackbox
+
+
+def test_env_step_runs_with_prob_reveal():
+    dataset, blackbox = _make_dataset_and_model(seed=42)
+    env = ExplainEnv(dataset=dataset, blackbox=blackbox, reveal="probs", seed=42)
     obs = env.reset()
+    assert "p" in obs and obs["x"].shape == (dataset.n_features,)
     e = "features suggest class 1 with strong signal"
-    out = env.step(e)
-    assert hasattr(out, 'reward')
+    out = env.step(e, tool_call_count=2)
+    assert hasattr(out, "reward")
+    assert np.isfinite(out.reward)
     assert out.done is True
+    assert out.info["tool_call_count"] == 2
+    assert "p" in out.observation and "y" not in out.observation
+
+
+def test_env_label_reveal_hides_probabilities():
+    dataset, blackbox = _make_dataset_and_model(seed=123)
+    env = ExplainEnv(dataset=dataset, blackbox=blackbox, reveal="label", seed=123)
+    obs = env.reset()
+    assert "y" in obs and "p" not in obs
+    out = env.step("short explanation", tool_call_count=1)
+    assert "y" in out.observation and "p" not in out.observation
+    assert out.info["tool_call_count"] == 1
+
+
+def test_tool_penalty_is_applied_to_reward():
+    dataset, blackbox = _make_dataset_and_model(seed=2023)
+    env = ExplainEnv(dataset=dataset, blackbox=blackbox, tool_penalty=0.25, seed=2023)
+    env.reset()
+    result = env.step("penalty test", tool_call_count=3)
+    expected = result.info["base_reward"] - 0.75
+    assert result.reward == pytest.approx(expected)
+
+
+def test_seeded_dataset_is_reproducible():
+    dataset, blackbox = _make_dataset_and_model(seed=777, dataset_size=32)
+    env_a = ExplainEnv(dataset=dataset, blackbox=blackbox, seed=777)
+    env_b = ExplainEnv(dataset=dataset, blackbox=blackbox, seed=777)
+
+    seq_a = [env_a.reset()["x"] for _ in range(5)]
+    seq_b = [env_b.reset()["x"] for _ in range(5)]
+
+    for xa, xb in zip(seq_a, seq_b):
+        np.testing.assert_allclose(xa, xb)

--- a/tests/test_env_real.py
+++ b/tests/test_env_real.py
@@ -1,0 +1,32 @@
+import numpy as np
+from sklearn.datasets import load_breast_cancer
+from sklearn.ensemble import RandomForestClassifier
+
+from src.data.datasets import TabularDataset
+from src.envs.explain_env import ExplainEnv
+from src.models.blackbox import BlackBoxModel
+
+
+def test_explain_env_real_dataset_smoke():
+    data = load_breast_cancer()
+    dataset = TabularDataset.from_arrays(
+        data.data,
+        data.target,
+        list(data.feature_names),
+    )
+    model = RandomForestClassifier(random_state=0)
+    model.fit(dataset.X, dataset.y)
+    blackbox = BlackBoxModel.from_sklearn(model, n_features=dataset.n_features)
+
+    env = ExplainEnv(dataset=dataset, blackbox=blackbox, reveal="probs", seed=0)
+    obs = env.reset()
+
+    assert set(obs.keys()) == {"x", "p"}
+    assert obs["x"].shape == (dataset.n_features,)
+    assert obs["p"].shape == (2,)
+    assert env.feature_names == list(data.feature_names)
+
+    result = env.step("dummy explanation", tool_call_count=0)
+    assert result.done is True
+    assert np.isfinite(result.reward)
+    assert "base_reward" in result.info

--- a/tests/test_g_explainer.py
+++ b/tests/test_g_explainer.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from src.models.g_explainer import ExplanationInducedModel
+
+
+def test_explanation_induced_model_smoke(tmp_path):
+    texts = [
+        "evidence leans toward class 0 due to mitigating factors",
+        "sharp increase in risk drives class 1 prediction",
+        "protective signal keeps probability near class 0",
+        "dominant influence lifts class 1 likelihood",
+        "negative contribution anchors class 0",
+        "positive contribution raises class 1",
+        "calming effect implies outcome 0",
+        "escalating trend implies outcome 1",
+    ]
+    y = [0, 1, 0, 1, 0, 1, 0, 1]
+
+    model = ExplanationInducedModel()
+    model.fit(texts, y)
+
+    probs = model.predict_proba(texts[:3])
+    assert probs.shape == (3, 2)
+    assert np.all(np.isfinite(probs))
+    assert np.allclose(probs.sum(axis=1), 1.0, atol=1e-6)
+
+    save_path = tmp_path / "explainer"
+    model.save(save_path)
+    loaded = ExplanationInducedModel.load(save_path)
+    loaded_probs = loaded.predict_proba(texts[:3])
+    assert np.allclose(probs, loaded_probs)

--- a/tests/test_ppo_smoke.py
+++ b/tests/test_ppo_smoke.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from src.training.train_ppo import PPOTrainingConfig, train
+
+
+def test_dummy_training_smoke():
+    cfg = PPOTrainingConfig(
+        model_name="dummy",
+        batch_size=2,
+        rollout_steps=2,
+        lr=1e-4,
+        target_kl=0.1,
+        seed=0,
+        max_new_tokens=8,
+        grad_accumulation_steps=1,
+    )
+    history = train(cfg)
+    assert history, "Expected at least one PPO update"
+    for stats in history:
+        assert "kl" in stats
+        assert "ref_kl" in stats
+
+
+def test_dummy_training_with_accumulation():
+    cfg = PPOTrainingConfig(
+        model_name="dummy",
+        batch_size=2,
+        rollout_steps=3,
+        lr=1e-4,
+        target_kl=0.1,
+        seed=123,
+        max_new_tokens=6,
+        grad_accumulation_steps=2,
+    )
+    history = train(cfg)
+    # Two updates: one after steps {0,1} and a final flush for step {2}
+    assert len(history) == 2
+    for stats in history:
+        assert "kl" in stats
+        assert "ref_kl" in stats

--- a/tests/test_tools_wrappers.py
+++ b/tests/test_tools_wrappers.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:  # pragma: no cover - import-time configuration
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.tools.lime_tool import make_lime_tool
+from src.tools.pdp_tool import make_pdp_tool
+from src.tools.shap_tool import make_shap_tool
+
+
+@pytest.fixture(scope="module")
+def logistic_setup():
+    X, y = make_classification(
+        n_samples=200,
+        n_features=4,
+        n_informative=3,
+        n_redundant=0,
+        random_state=42,
+    )
+    model = LogisticRegression(max_iter=1000, solver="lbfgs").fit(X, y)
+    feature_grid = {
+        i: np.linspace(X[:, i].min(), X[:, i].max(), num=6, dtype=float)
+        for i in range(X.shape[1])
+    }
+    return X, model, feature_grid
+
+
+def test_shap_tool_returns_top_k(logistic_setup):
+    X, model, _ = logistic_setup
+    tool = make_shap_tool(model.predict_proba, X[:50])
+    x = X[0]
+    result = tool(x, top_k=3)
+    assert isinstance(result, list)
+    assert len(result) == 3
+    magnitudes = []
+    for idx, value in result:
+        assert isinstance(idx, int)
+        assert 0 <= idx < X.shape[1]
+        assert np.isfinite(value)
+        magnitudes.append(abs(value))
+    assert magnitudes == sorted(magnitudes, reverse=True)
+
+
+def test_lime_tool_produces_coefficients(logistic_setup):
+    X, model, _ = logistic_setup
+    feature_names = [f"f{i}" for i in range(X.shape[1])]
+    tool = make_lime_tool(
+        model.predict_proba,
+        feature_names,
+        training_data=X[:100],
+        n_samples=256,
+        random_state=123,
+    )
+    explanation = tool(X[1])
+    assert explanation["method"] == "LIME"
+    coeffs = np.asarray(explanation["coefficients"], dtype=float)
+    assert coeffs.shape == (X.shape[1],)
+    assert np.all(np.isfinite(coeffs))
+    assert np.isfinite(float(explanation["intercept"]))
+    assert 0.0 <= float(explanation["r2"]) <= 1.0
+    assert isinstance(explanation["target_class"], int)
+
+
+def test_pdp_tool_returns_curve(logistic_setup):
+    X, model, feature_grid = logistic_setup
+    tool = make_pdp_tool(model.predict_proba, feature_grid, background=X[:40])
+    feature_idx = 1
+    pdp = tool(X[2], feature_idx)
+    grid = np.asarray(pdp["grid"], dtype=float)
+    assert grid.shape[0] == feature_grid[feature_idx].shape[0]
+    curve = np.asarray(pdp["pdp"], dtype=float)
+    ice = np.asarray(pdp["ice"], dtype=float)
+    assert curve.shape == grid.shape
+    assert ice.shape == grid.shape
+    assert np.all(np.isfinite(curve))
+    assert np.all(np.isfinite(ice))
+    assert pdp["feature"] == feature_idx
+    assert isinstance(pdp["target_class"], int)
+


### PR DESCRIPTION
## Summary
- update `ExplainEnv` to consume provided `TabularDataset`/`BlackBoxModel` pairs while keeping deterministic sampling and reveal modes
- add a helper in the PPO training script to build the synthetic dataset/black-box pair used for smoke tests and training entrypoints
- refresh environment unit tests and introduce a real-data smoke test that exercises wrapping a trained RandomForestClassifier

## Testing
- PYTHONPATH=. pytest tests/test_env.py tests/test_env_real.py -q
- PYTHONPATH=. pytest tests/test_ppo_smoke.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c9cdbcd0688329a068d250f680044d